### PR TITLE
Fix for clearedAmount gt requirementAmount

### DIFF
--- a/scratchcard.js
+++ b/scratchcard.js
@@ -137,7 +137,7 @@ ScratchCard.prototype.calcPixels = function (stride) {
 };
 
 ScratchCard.prototype.clearPercentage = function (clearedAmount) {
-  if (clearedAmount === this.clearRequirement) {
+  if ((clearedAmount === this.clearRequirement) || (clearedAmount > this.clearRequirement)) {
     var successEvent = new Event('success');
     this.can.dispatchEvent(successEvent);
   }


### PR DESCRIPTION
Earlier, the success event was dispatched only when the clearedAmount was exactly equal to the requirement. Whereas, when the user holds the mouse for sometime and clears, usually it surpass this amount. Hence, its important to also trigger success if the clearedAmount is greater than the requirement.